### PR TITLE
Modify/doc LuaFunction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ addons/lua-gdextension/CHANGELOG.md
 addons/lua-gdextension/README.md
 addons/lua-gdextension/LICENSE
 src/generated/
-src/gen/
+src/generated-document/
 
 # Test project files
 .godot/

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ addons/lua-gdextension/CHANGELOG.md
 addons/lua-gdextension/README.md
 addons/lua-gdextension/LICENSE
 src/generated/
-src/gen/doc_data.gen.cpp
+src/gen/
 
 # Test project files
 .godot/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ addons/lua-gdextension/CHANGELOG.md
 addons/lua-gdextension/README.md
 addons/lua-gdextension/LICENSE
 src/generated/
+src/gen/doc_data.gen.cpp
 
 # Test project files
 .godot/

--- a/SConstruct
+++ b/SConstruct
@@ -77,7 +77,7 @@ sources = [
 
 # Generate document
 if env["target"] in ["editor", "template_debug"]:
-    doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc/*.xml"))
+    doc_data = env.GodotCPPDocData("src/generated-document/doc_data.gen.cpp", source=Glob("doc/*.xml"))
     sources.append(doc_data)
 
 library = env.SharedLibrary(

--- a/doc/LuaFunction.xml
+++ b/doc/LuaFunction.xml
@@ -50,7 +50,7 @@
 		<method name="to_callable">
 			<return type="Callable" />
 			<description>
-				Converts the Lua function to a [class Callable] object.
+				Converts the Lua function to a [Callable] object.
 				[codeblocks]
 				[gdscript]
 				var lua_state = LuaState.new()

--- a/doc/LuaFunction.xml
+++ b/doc/LuaFunction.xml
@@ -19,6 +19,7 @@
 				If the function returns a single value, it is returned directly.
 				[codeblocks]
 				[gdscript]
+				var lua_state = LuaState.new()
 				var add_function = lua_state.load_string("return function(a, b) return a + b end")
 				# Call function using invoke
 				var result = add_function.invoke(1, 2)
@@ -37,9 +38,27 @@
 				If the function returns a single value, it is returned directly.
 				[codeblocks]
 				[gdscript]
+				var lua_state = LuaState.new()
 				var add_function = lua_state.load_string("return function(a, b) return a + b end")
 				# Call function using invokev
 				var result = add_function.invokev([1, 2])
+				print(result) # Prints 3
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="to_callable">
+			<return type="Callable" />
+			<description>
+				Converts the Lua function to a [class Callable] object.
+				[codeblocks]
+				[gdscript]
+				var lua_state = LuaState.new()
+				var add_function = lua_state.do_string("return function(a, b) return a + b end")
+				# Convert to Callable
+				var callable = add_function.to_callable()
+				# Use in GDScript
+				var result = callable.call(1, 2)
 				print(result) # Prints 3
 				[/gdscript]
 				[/codeblocks]


### PR DESCRIPTION
Add the generated documentation cpp files during compilation to .gitignore to prevent committing these unnecessary files.
Modify the name of the generated folder to avoid unnecessary misunderstandings.
The missing method documentation of LuaFunction to_callable has been added